### PR TITLE
.npmignore: Do not package tmp/ dir and remove 106 MB of garbage from the package.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 bower_components/
 tests/
+tmp/
 
 .bowerrc
 .editorconfig


### PR DESCRIPTION
_Note: I am not a user of this package. Also, I am aware that this is unsupported in favor of `emberfire`, but I still think that you should merge this change and re-package a new patch version (if you are not planning to unpublish the whole package altogether)._

Atm, your package installed size is **115 MB**, from which **106 MB** resides in the `tmp` dir and is just garbage.

This pull requests saves you those 106MB (92%) of the installed size.
If whomever still uses this package, he or she should receive an update.

See https://github.com/ember-cli/ember-cli/issues/4199 for details.

After merging, a new version should be released and uploaded to npm for this to have an affect.
